### PR TITLE
Fix: Correct ordering and exactness of the UI Routes in BrewYah

### DIFF
--- a/src/main/ui/BrewYah.js
+++ b/src/main/ui/BrewYah.js
@@ -4,15 +4,13 @@ import {BrowserRouter, Switch, Route, Link} from 'react-router-dom';
 import Braumeister from "braumeister";
 import Taproom from "taproom";
 
-class BrewYah extends React.Component {
-    render(props) {
-        return (<BrowserRouter>
-            <Switch>
-                <Route exact path='/' component={Taproom}></Route>
-                <Route exact path='/admin' component={Braumeister}></Route>
-            </Switch>
-        </BrowserRouter>);
-    }
-}
+const BrewYah = () => (
+    <BrowserRouter>
+        <Switch>
+            <Route path='/admin' component={Braumeister}/>
+            <Route path='/' component={Taproom}/>
+        </Switch>
+    </BrowserRouter>
+);
 
 ReactDOM.render(<BrewYah/>, document.getElementById('brewyah'));


### PR DESCRIPTION
* Since `/` matches on everything, ensure that specific `Route`s, like `/admin` get processed first. 
* Remove the `exact` qualifiers to enable nesting. `exact path=/admin` won't match on `/admin/foo`.